### PR TITLE
Expanded the build system with unlock/erase/prog.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ SET(CMAKE_SYSTEM_VERSION 1)
 
 
 #
-# Set Toolchain Path Below
+# Set toolchain path below.
 #
 
 if (UNIX)
@@ -17,6 +17,16 @@ else ()
     CMAKE_FORCE_C_COMPILER(${TOOLCHAIN_DIR}/arm-none-eabi-gcc.exe GNU)
     CMAKE_FORCE_CXX_COMPILER(${TOOLCHAIN_DIR}/arm-none-eabi-g++.exe GNU)
 endif ()
+
+
+#
+# Select a method of programming below.
+#
+
+set(USE_OPENOCD "true")
+#set(USE_ST_FLASH "true")
+#set(USE_BLACK_MAGIC "true")
+
 
 project(RS41FOX C CXX)
 
@@ -54,12 +64,142 @@ add_custom_command(TARGET ${PROJECT_NAME}.elf POST_BUILD
 
 set(CMAKE_CXX_STANDARD 11)
 
+
+#
+# make erase
+#
+# Does a security unlock, followed by a flash erase.
+#
+# Just doing an unlock on its own would only erase the flash, if the device had
+# previously been locked. To avoid surprising the user, we always erase the
+# flash.
+#
+# Note that security unlock is currently only supported if using openocd.
+#
+#
+# make halt
+#
+# Resets and then halts the device.
+#
+#
+# make run
+#
+# Resets and then runs the device.
+#
+#
+# make program-halt
+#
+# Programs the device, and leaves it halted.
+#
+# Does not require the device to be erased first, although it must not be
+# security locked.
+#
+#
+# make program
+#
+# Programs the device, and allows it to run after reset.
+#
+# Does not require the device to be erased first, although it must not be
+# security locked.
+#
+
+
+if (USE_OPENOCD)
+
+add_custom_target(erase
+        COMMENT "Unlocking and erasing device"
+        COMMAND openocd -f interface/stlink-v2.cfg -f target/stm32f1x.cfg -c \"init\; reset halt\; stm32f1x unlock 0\; reset halt\; flash protect 0 0 last off\; reset halt\; flash erase_sector 0 0 last\; reset halt\; exit\"
+)
+add_custom_target(halt
+        COMMENT "Resetting and halting device"
+        COMMAND openocd -f interface/stlink-v2.cfg -f target/stm32f1x.cfg -c \"init\; reset halt\; exit\"
+)
+add_custom_target(run
+        COMMENT "Resetting device and then running"
+        COMMAND openocd -f interface/stlink-v2.cfg -f target/stm32f1x.cfg -c \"init\; reset\; exit\"
+)
+add_custom_target(program-halt
+        DEPENDS ${PROJECT_NAME}.elf
+        COMMENT "Programming device with ${HEX_FILE}, and then halting"
+        COMMAND openocd -f interface/stlink-v2.cfg -f target/stm32f1x.cfg -c \"program ${HEX_FILE} verify exit\"
+)
 add_custom_target(program
         DEPENDS ${PROJECT_NAME}.elf
+        COMMENT "Programming device with ${HEX_FILE}, and then running"
+        COMMAND openocd -f interface/stlink-v2.cfg -f target/stm32f1x.cfg -c \"program ${HEX_FILE} verify reset exit\"
+)
 
-        if (UNIX)
-            COMMAND st-flash --reset write ${BIN_FILE} 0x08000000
-        else ()
-            COMMAND D:/Programy/stlink-1.3.0-win64/bin/st-flash --reset write ${BIN_FILE} 0x08000000
-        endif ()
-        COMMENT "flashing ${BIN_FILE}")
+elseif (USE_ST_FLASH)
+
+add_custom_target(erase
+        COMMENT "Erasing device"
+        COMMAND st-flash erase
+        COMMAND echo If unlocking is required, please select openocd in CMakeLists.txt
+)
+add_custom_target(halt
+        COMMENT "Halting the device is not supported by st-link"
+        COMMAND echo If halting is required, please select openocd in CMakeLists.txt
+)
+add_custom_target(run
+        COMMENT "Resetting device and then running"
+        COMMAND st-flash reset
+)
+add_custom_target(program-halt
+        COMMENT "Halting the device is not supported by st-link"
+        COMMAND echo If halting is required, please select openocd in CMakeLists.txt
+)
+add_custom_target(program
+        DEPENDS ${PROJECT_NAME}.elf
+        COMMENT "Programming device with ${HEX_FILE}, and then running"
+        COMMAND st-flash --reset --format ihex write ${HEX_FILE}
+)
+
+elseif (USE_BLACK_MAGIC)
+
+add_custom_target(erase
+        COMMENT "Erasing the device is not supported with Black Magic Probe"
+        COMMAND echo If erasing is required, please select another programming method in CMakeLists.txt
+)
+add_custom_target(halt
+        COMMENT "Halting the device is not supported with Black Magic Probe"
+        COMMAND echo If halting is required, please select openocd in CMakeLists.txt
+)
+add_custom_target(run
+        COMMENT "make run is not supported with Black Magic Probe"
+        COMMAND echo If erasing is required, please select another programming method in CMakeLists.txt
+)
+add_custom_target(program-halt
+        COMMENT "Halting the device is not supported with Black Magic Probe"
+        COMMAND echo If halting is required, please select openocd in CMakeLists.txt
+)
+add_custom_target(program
+        DEPENDS ${PROJECT_NAME}.elf
+        COMMENT "Programming device with ${PROJECT_NAME}.elf, and then running"
+        COMMAND chmod u+x flash.sh
+        COMMAND ./flash.sh
+)
+
+else ()
+
+add_custom_target(erase
+        COMMENT "No method of programming is available"
+        COMMAND echo Edit CMakeLists.txt and select a method of programming.
+)
+add_custom_target(halt
+        COMMENT "No method of programming is available"
+        COMMAND echo Edit CMakeLists.txt and select a method of programming.
+)
+add_custom_target(run
+        COMMENT "No method of programming is available"
+        COMMAND echo Edit CMakeLists.txt and select a method of programming.
+)
+add_custom_target(program-halt
+        COMMENT "No method of programming is available"
+        COMMAND echo Edit CMakeLists.txt and select a method of programming.
+)
+add_custom_target(program
+        COMMENT "No method of programming is available"
+        COMMAND echo Edit CMakeLists.txt and select a method of programming.
+)
+
+endif ()

--- a/README.md
+++ b/README.md
@@ -30,24 +30,24 @@ Either:
 * [stlink](https://github.com/texane/stlink) under Linux/OSX/Windows, or
 * Use `flash.sh` with a [Black Magic Probe](https://1bitsquared.com/products/black-magic-probe). You will need to modify this script with the path to the debugger's serial interface.
 
-Only the proprietary ST-LINK utility, or openocd, are known to support unlocking the device to remove the original manufacturer's firmaware.
+Only the proprietary ST-LINK utility, or openocd, are known to support unlocking the device to remove the original manufacturer's firmware.
 
 Refer to [this file](./docs/programming_header.md) for programming header pinouts. Note that you will need to power up the RS41 using the power button, before you will be able to interact with the MCU chip.
 
 Please do not allow the RS41 to run the original manufacturer's firmware, as this will result in unlicensed radio transmissions. With the reset line connected to a debugger, it is possible to keep the MCU halted. However if the LED lights up after pressing the power button, then some firmware is definitely running - please erase the original firmware ASAP, or remove the batteries.
 
-The build system supports a number of useful operations via openocd or st-link:
-* `make erase` erases the flash, and if using `openocd`, unlocks a locked device
+The build system supports a number of useful operations via openocd or stlink:
+* `make erase` erases the flash, and if using openocd, unlocks a locked device
 * `make halt` resets and halts the device
 * `make run` resets the device and lets it run
 * `make program-halt` programs the device and halts it
 * `make program` programs the device and lets it run
 
-Additionally `make program` is supported with Black Magic Probe. Currently `halt` and `program-halt` is not supported with `st-link`. The `program` targets will first compile the firmware, if it is not up to date.
+Additionally `make program` is supported with Black Magic Probe. Currently `halt` and `program-halt` are not supported with stlink. The `program` targets will first compile the firmware, if it is not up to date.
 
 A typical sequence for programming a freshly acquired RS41, would be:
 * openocd: `make erase program-halt`
-* st-link: Unlock the device using the Windows version of ST-LINK, and clear the flash page protection bits. Then program using either the proprietary ST-LINK, or the free replacement.
+* stlink: Unlock the device using the proprietary (Windows) version of ST-LINK, and clear the flash page protection bits. Then program using either the proprietary ST-LINK, or the free replacement.
 
 An already unlocked RS41 does not require `make erase` before programming. Always remember to press the power button after inserting batteries, or the MCU will not be powered for programming.
 

--- a/README.md
+++ b/README.md
@@ -19,16 +19,37 @@ Configuration settings are located in [config.h](./config.h). Modify as appropri
 * Extract the tarball to somewhere useful. In my case I'm using ~/opt/
 * Within the RS41HUP directory:
   * Edit CMakeLists.txt and set the correct path to the un-tar'd directory.
+  * Optionally enable a method of programming, in CMakeLists.txt.
   * `cmake .`
   * `make`
 
 ## Programming
 Either:
 * Use the ST Micro ST-LINK utility (Windows only), or
-* [stlink](https://github.com/texane/stlink) under Linux/OSX (though I haven't had much success with this yet...), or
-* Use `flash.sh` with a [Black Magic Probe](https://1bitsquared.com/products/black-magic-probe). You will need to modify the path to the debugger's serial interface. I haven't been able to do the initial erase/program via this method.
+* [openocd](http://openocd.org) under Linux/OSX/Windows, or
+* [stlink](https://github.com/texane/stlink) under Linux/OSX/Windows, or
+* Use `flash.sh` with a [Black Magic Probe](https://1bitsquared.com/products/black-magic-probe). You will need to modify this script with the path to the debugger's serial interface.
 
-Refer to [this file](./docs/programming_header.md) for programming header pinouts. Note that you will need to power up the RS41 using the power button before you will be able to flash the chip.
+Only the proprietary ST-LINK utility, or openocd, are known to support unlocking the device to remove the original manufacturer's firmaware.
+
+Refer to [this file](./docs/programming_header.md) for programming header pinouts. Note that you will need to power up the RS41 using the power button, before you will be able to interact with the MCU chip.
+
+Please do not allow the RS41 to run the original manufacturer's firmware, as this will result in unlicensed radio transmissions. With the reset line connected to a debugger, it is possible to keep the MCU halted. However if the LED lights up after pressing the power button, then some firmware is definitely running - please erase the original firmware ASAP, or remove the batteries.
+
+The build system supports a number of useful operations via openocd or st-link:
+* `make erase` erases the flash, and if using `openocd`, unlocks a locked device
+* `make halt` resets and halts the device
+* `make run` resets the device and lets it run
+* `make program-halt` programs the device and halts it
+* `make program` programs the device and lets it run
+
+Additionally `make program` is supported with Black Magic Probe. Currently `halt` and `program-halt` is not supported with `st-link`. The `program` targets will first compile the firmware, if it is not up to date.
+
+A typical sequence for programming a freshly acquired RS41, would be:
+* openocd: `make erase program-halt`
+* st-link: Unlock the device using the Windows version of ST-LINK, and clear the flash page protection bits. Then program using either the proprietary ST-LINK, or the free replacement.
+
+An already unlocked RS41 does not require `make erase` before programming. Always remember to press the power button after inserting batteries, or the MCU will not be powered for programming.
 
 ## Usage
 * Program as above.


### PR DESCRIPTION
I managed to get RS41s to unlock and flash entirely from Ubuntu, using openocd. So I've extended the build system to support openocd, and I've added some additional useful operations, such as program and halt, vs program and run.