### PR TITLE
Move ADCVal into init.c

### DIFF
--- a/init.c
+++ b/init.c
@@ -11,6 +11,8 @@
 #include "init.h"
 #include "radio.h"
 
+__IO uint16_t ADCVal[2];
+
 SPI_InitTypeDef   SPI_InitStructure;
 USART_InitTypeDef USART_InitStructure;
 GPIO_InitTypeDef GPIO_Conf;

--- a/init.h
+++ b/init.h
@@ -1,4 +1,4 @@
-__IO uint16_t ADCVal[2];
+extern __IO uint16_t ADCVal[2];
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Fixes #2.

This corrects the following linker error:
```
/usr/lib/gcc/arm-none-eabi/10.3.1/../../../arm-none-eabi/bin/ld: CMakeFiles/RS41FOX.elf.dir/main.c.obj:/home/argilo/git/RS41FOX/init.h:1: multiple definition of `ADCVal'; CMakeFiles/RS41FOX.elf.dir/init.c.obj:/home/argilo/git/RS41FOX/init.h:1: first defined here
/usr/lib/gcc/arm-none-eabi/10.3.1/../../../arm-none-eabi/bin/ld: CMakeFiles/RS41FOX.elf.dir/ublox.c.obj:/home/argilo/git/RS41FOX/init.h:1: multiple definition of `ADCVal'; CMakeFiles/RS41FOX.elf.dir/init.c.obj:/home/argilo/git/RS41FOX/init.h:1: first defined here
collect2: error: ld returned 1 exit status
```