### PR TITLE
Add slash to morse symbols

### DIFF
--- a/morse.c
+++ b/morse.c
@@ -1,6 +1,6 @@
 //
-//	Morse Code Playback Functions
-//	Mark Jessop 2018-04
+//  Morse Code Playback Functions
+//  Mark Jessop 2018-04
 //
 //  Based on code from https://github.com/Paradoxis/Arduino-morse-code-translator/blob/master/main.ino
 //
@@ -54,7 +54,7 @@ char* MORSE_NUMBERS[] = {
 
 // Symbols (though we handle this in a bit of a hacky way.)
 char* MORSE_SYMBOLS[] = {
-	".-.-.-" // .
+  ".-.-.-" // .
 };
 
 
@@ -75,7 +75,7 @@ void sendDotOrDash (char unit) {
 
   // Inter-element gap
   radio_inhibit_tx();
-  _delay_ms(MORSE_DELAY); 
+  _delay_ms(MORSE_DELAY);
 }
 
 
@@ -96,45 +96,45 @@ void sendMorseSequence (char* sequence) {
 
 
 
-void sendMorse(char* message){
+void sendMorse(char* message) {
 
-	int i = 0;
-	while (message[i] != '\0'){
-		char current = message[i];
+  int i = 0;
+  while (message[i] != '\0') {
+    char current = message[i];
 
-		// Lower case letters
-	    if (current >= 'a' && current <= 'z') {
-	      sendMorseSequence(MORSE_LETTERS[current - 'a']);
-	    }
+      // Lower case letters
+      if (current >= 'a' && current <= 'z') {
+        sendMorseSequence(MORSE_LETTERS[current - 'a']);
+      }
 
-	    // Capital case letters
-	    else if (current >= 'A' && current <= 'Z') {
-	      sendMorseSequence(MORSE_LETTERS[current - 'A']);
-	    }
+      // Capital case letters
+      else if (current >= 'A' && current <= 'Z') {
+        sendMorseSequence(MORSE_LETTERS[current - 'A']);
+      }
 
-	    // Numbers
-	    else if (current >= '0' && current <= '9') {
-	      sendMorseSequence(MORSE_NUMBERS[current - '0']);
-	    }
+      // Numbers
+      else if (current >= '0' && current <= '9') {
+        sendMorseSequence(MORSE_NUMBERS[current - '0']);
+      }
 
-	    else if (current == '.'){
-	    	sendMorseSequence(MORSE_SYMBOLS[0]);
-	    }
+      else if (current == '.') {
+        sendMorseSequence(MORSE_SYMBOLS[0]);
+      }
 
-	    // Space character (3500  ms)
-	    else if (current == ' ') {
-	      _delay_ms(MORSE_DELAY_SPACE);
-	    }
+      // Space character (3500  ms)
+      else if (current == ' ') {
+        _delay_ms(MORSE_DELAY_SPACE);
+      }
 
-	    // Treat all other characters as a space.
-	    else{
-	    	_delay_ms(MORSE_DELAY_SPACE);
-	    }
+      // Treat all other characters as a space.
+      else {
+        _delay_ms(MORSE_DELAY_SPACE);
+      }
 
-		i++;
-	}
+    i++;
+  }
 
-	radio_disable_tx();
+  radio_disable_tx();
 }
 
 

--- a/morse.c
+++ b/morse.c
@@ -54,7 +54,8 @@ char* MORSE_NUMBERS[] = {
 
 // Symbols (though we handle this in a bit of a hacky way.)
 char* MORSE_SYMBOLS[] = {
-  ".-.-.-" // .
+  ".-.-.-", // .
+  "-..-."   // /
 };
 
 
@@ -119,6 +120,10 @@ void sendMorse(char* message) {
 
       else if (current == '.') {
         sendMorseSequence(MORSE_SYMBOLS[0]);
+      }
+
+      else if (current == '/') {
+        sendMorseSequence(MORSE_SYMBOLS[1]);
       }
 
       // Space character (3500  ms)

--- a/morse.h
+++ b/morse.h
@@ -1,6 +1,6 @@
 //
-//	Morse Code Playback Functions
-//	Mark Jessop 2018-04
+//  Morse Code Playback Functions
+//  Mark Jessop 2018-04
 //
 #ifndef RS41FOX_MORSE_H
 #define RS41FOX_MORSE_H


### PR DESCRIPTION
The slash character is sometimes required in call signs, so I've added it here.

I also included a separate commit to clean up whitespace in the morse files, since there was a mixture of tabs and spaces that made the files a bit difficult to work with.