### PR TITLE
Add power button support

### DIFF
--- a/config.h
+++ b/config.h
@@ -53,6 +53,10 @@
 // Set this to < 1 Volt for (essentially) no low-voltage cutout.
 #define LOW_VOLTAGE_CUTOUT 0.5 // Volts
 
+// Power Button Debounce Time in ms - Set this to 0 to disable the power button. Set this to the desired turn-off
+// time in milliseconds (typically 1000) to enable the power button. The power button must be held for this time to
+// turn off the fox. 
+#define POWER_BUTTON_DEBOUNCE_TIME 1000
 
 #endif
 #endif //RS41HUP_CONFIG_H

--- a/config.h
+++ b/config.h
@@ -54,9 +54,9 @@
 #define LOW_VOLTAGE_CUTOUT 0.5 // Volts
 
 // Power Button Debounce Time in ms - Set this to 0 to disable the power button. Set this to the desired turn-off
-// time in milliseconds (typically 1000) to enable the power button. The power button must be held for this time to
+// time in milliseconds (typically 500) to enable the power button. The power button must be held for this time to
 // turn off the fox. 
-#define POWER_BUTTON_DEBOUNCE_TIME 1000
+#define POWER_BUTTON_DEBOUNCE_TIME 500
 
 #endif
 #endif //RS41HUP_CONFIG_H

--- a/main.c
+++ b/main.c
@@ -45,6 +45,7 @@ void send_low_battery_beacon();
 void power_down();
 void check_supply_voltage();
 void check_gps_lock();
+void check_power_button();
 
 /**
  * GPS data processing
@@ -218,4 +219,24 @@ void check_gps_lock(){
     ublox_gps_stop();
   }
 
+}
+
+void check_power_button(){
+  #if POWER_BUTTON_DEBOUNCE_TIME
+
+  const static uint16_t button_pressed_threshold = 2000;
+
+  // Increase a counter for each cycle that the power button is pressed.
+  // When count exceeds the equivalent debounce time, power down.
+  uint16_t count = 0;
+  do {
+    count++;
+    _delay_ms(25);
+    
+    if(count > (POWER_BUTTON_DEBOUNCE_TIME / 25)) {
+      power_down();
+    }
+  } while (ADCVal[1] > button_pressed_threshold);
+
+  #endif
 }

--- a/main.c
+++ b/main.c
@@ -115,15 +115,22 @@ int main(void) {
 
     for(int k = 0; k < ONOFF_REPEATS; k++){
       radio_enable_tx();
-      _delay_ms(ON_TIME*1000);
+      for(int i = 0; i < ON_TIME; i++){
+        check_power_button();
+        _delay_ms(1000);
+      }
       radio_disable_tx();
-      _delay_ms(OFF_TIME*1000);
+      for(int i = 0; i < ON_TIME; i++){
+        check_power_button();
+        _delay_ms(1000);
+      }
     }
 
     #ifdef LOW_VOLTAGE_BEACON
     check_gps_lock();
     #endif
     check_supply_voltage();
+    check_power_button();
 
   }
 
@@ -234,6 +241,24 @@ void check_power_button(){
     _delay_ms(25);
     
     if(count > (POWER_BUTTON_DEBOUNCE_TIME / 25)) {
+      // The user-initiated power off sequence needs to have an acknowledgement and delay so they release the power button.
+      // Continuing to press the power button after shutdown is asserted will turn the RS41 on again.
+
+      // Disable transmit and enable the green LED (in an "ACK" sort of way)
+      radio_disable_tx();
+      GPIO_ResetBits(GPIOB, GREEN);
+      _delay_ms(500);
+      GPIO_SetBits(GPIOB, GREEN);
+      
+      // Flash the red LED and transmit 3 times
+      for(int i = 0; i < 3; i++) {
+        radio_enable_tx();
+        GPIO_ResetBits(GPIOB, RED);
+        _delay_ms(750);
+        radio_disable_tx();
+        GPIO_SetBits(GPIOB, RED);
+        _delay_ms(250);
+      }
       power_down();
     }
   } while (ADCVal[1] > button_pressed_threshold);


### PR DESCRIPTION
This handful of changes will allow you to power the fox off by pressing the power button during the DELAY_ON period. I believe the method I chose was the best way to do it without adding a timer and interrupts. The green LED will acknowledge when the button has been pressed. There will be a quick power down sequence, and then the RS41 shutdown pin will be asserted. 