### PR TITLE
Fix removal of OFF_TIME from transmission loop

### DIFF
--- a/main.c
+++ b/main.c
@@ -120,7 +120,7 @@ int main(void) {
         _delay_ms(1000);
       }
       radio_disable_tx();
-      for(int i = 0; i < ON_TIME; i++){
+      for(int i = 0; i < OFF_TIME; i++){
         check_power_button();
         _delay_ms(1000);
       }


### PR DESCRIPTION
During a recent change, the OFF_TIME setting was accidentally replaced with ON_TIME inside the main transmission loop. This PR contains the one line fix to put it back.