### PR TITLE
Add FM CW support

### DIFF
--- a/config.h
+++ b/config.h
@@ -12,7 +12,7 @@
 #define TRANSMIT_FREQUENCY  434.650f // MHz. (Default is within the ISM band. ARDF Frequency in Australia is 439.4 MHz) 
 #define CALLSIGN "N0CALL" // Put your callsign here, max. 15 characters
 
-//#define MODULATE_FM // Enable CW via FM tone generation (leave commented for CW)
+#define MODULATE_FM // Enable CW via FM tone generation (leave commented for CW)
 #define FM_TONE_FREQ 1000 // FM CW modulation frequency (in Hz)
 #define FM_TX_DELAY 500 // TX delay in ms
 

--- a/config.h
+++ b/config.h
@@ -12,7 +12,7 @@
 #define TRANSMIT_FREQUENCY  434.650f // MHz. (Default is within the ISM band. ARDF Frequency in Australia is 439.4 MHz) 
 #define CALLSIGN "N0CALL" // Put your callsign here, max. 15 characters
 
-#define MODULATE_FM // Enable CW via FM tone generation (leave commented for CW)
+//#define MODULATE_FM // Enable CW via FM tone generation (leave commented for CW)
 #define FM_TONE_FREQ 1000 // FM CW modulation frequency (in Hz)
 #define FM_TX_DELAY 500 // TX delay in ms
 

--- a/config.h
+++ b/config.h
@@ -12,6 +12,10 @@
 #define TRANSMIT_FREQUENCY  434.650f // MHz. (Default is within the ISM band. ARDF Frequency in Australia is 439.4 MHz) 
 #define CALLSIGN "N0CALL" // Put your callsign here, max. 15 characters
 
+#define MODULATE_FM // Enable CW via FM tone generation (leave commented for CW)
+#define FM_TONE_FREQ 1000 // FM CW modulation frequency (in Hz)
+#define FM_TX_DELAY 500 // TX delay in ms
+
 // TX Power
 #define TX_POWER  5 // PWR 0...7 0- MIN ... 7 - MAX
 // Power Levels measured at 434.650 MHz, using a Rigol DSA815, and a 10 kHz RBW

--- a/init.c
+++ b/init.c
@@ -81,24 +81,27 @@ void NVIC_Conf()
 
 void RCC_Conf()
 {
-	 ErrorStatus HSEStartUpStatus;
-	  RCC_DeInit();
-	  RCC_HSEConfig(RCC_HSE_ON);
-	  HSEStartUpStatus = RCC_WaitForHSEStartUp();
-	  if(HSEStartUpStatus == SUCCESS)
-	  {
-			FLASH_PrefetchBufferCmd(FLASH_PrefetchBuffer_Enable);
-			FLASH_SetLatency(FLASH_Latency_2);
-			RCC_HCLKConfig(RCC_SYSCLK_Div4);
-			RCC_PCLK2Config(RCC_HCLK_Div4);
-			RCC_PCLK1Config(RCC_HCLK_Div2);
-			RCC_SYSCLKConfig(RCC_SYSCLKSource_HSE);
-			while(RCC_GetSYSCLKSource() != 0x04);
-  }
+	ErrorStatus HSEStartUpStatus;
+	RCC_DeInit();
+	RCC_HSEConfig(RCC_HSE_ON);
+	HSEStartUpStatus = RCC_WaitForHSEStartUp();
+	if(HSEStartUpStatus == SUCCESS)
+	{
+		FLASH_PrefetchBufferCmd(FLASH_PrefetchBuffer_Enable);
+		FLASH_SetLatency(FLASH_Latency_2);
+		RCC_HCLKConfig(RCC_SYSCLK_Div4);
+		RCC_PCLK2Config(RCC_HCLK_Div4);
+		RCC_PCLK1Config(RCC_HCLK_Div2);
+		RCC_SYSCLKConfig(RCC_SYSCLKSource_HSE);
+		while(RCC_GetSYSCLKSource() != 0x04);
+	}
 }
 
 void init_port()
 {
+	RCC_APB2PeriphClockCmd(RCC_APB2Periph_AFIO, ENABLE);
+	RCC_APB2PeriphResetCmd(RCC_APB2Periph_AFIO, DISABLE);
+	
 	RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE);
 	GPIO_Conf.GPIO_Pin = GPIO_Pin_12;
 	GPIO_Conf.GPIO_Mode = GPIO_Mode_Out_PP;

--- a/init.c
+++ b/init.c
@@ -99,9 +99,6 @@ void RCC_Conf()
 
 void init_port()
 {
-	RCC_APB2PeriphClockCmd(RCC_APB2Periph_AFIO, ENABLE);
-	RCC_APB2PeriphResetCmd(RCC_APB2Periph_AFIO, DISABLE);
-	
 	RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE);
 	GPIO_Conf.GPIO_Pin = GPIO_Pin_12;
 	GPIO_Conf.GPIO_Mode = GPIO_Mode_Out_PP;

--- a/init.h
+++ b/init.h
@@ -16,6 +16,7 @@ void init_usart_gps(const uint32_t speed, const uint8_t enable_irq);
 void spi_init();
 
 void spi_deinit();
+
 #ifdef __cplusplus
 }
 #endif

--- a/init.h
+++ b/init.h
@@ -16,7 +16,6 @@ void init_usart_gps(const uint32_t speed, const uint8_t enable_irq);
 void spi_init();
 
 void spi_deinit();
-
 #ifdef __cplusplus
 }
 #endif

--- a/main.c
+++ b/main.c
@@ -21,7 +21,6 @@
 #include "util.h"
 #include "morse.h"
 
-
 // IO Pin Definitions. The state of these pins are initilised in init.c
 #define GREEN  GPIO_Pin_7 // Inverted
 #define RED  GPIO_Pin_8 // Non-Inverted (?)
@@ -107,6 +106,16 @@ int main(void) {
   ublox_gps_stop();
   #endif
 
+  // radio_enable_tx();
+  // radio_enable_tone();
+
+  // uint16_t tone;
+
+  // while(1) {
+  //   tone = pwm_calculate_period(500);
+  //   pwm_timer_set_frequency(tone);
+  // }
+
   // Main Transmission Loop.
   while (1) {
     // Loop.
@@ -115,11 +124,14 @@ int main(void) {
 
     for(int k = 0; k < ONOFF_REPEATS; k++){
       radio_enable_tx();
+      radio_enable_tone();
       for(int i = 0; i < ON_TIME; i++){
         check_power_button();
         _delay_ms(1000);
       }
+      radio_inhibit_tone();
       radio_disable_tx();
+
       for(int i = 0; i < OFF_TIME; i++){
         check_power_button();
         _delay_ms(1000);
@@ -131,9 +143,7 @@ int main(void) {
     #endif
     check_supply_voltage();
     check_power_button();
-
   }
-
 }
 
 // Possible power savings?

--- a/main.c
+++ b/main.c
@@ -106,16 +106,6 @@ int main(void) {
   ublox_gps_stop();
   #endif
 
-  // radio_enable_tx();
-  // radio_enable_tone();
-
-  // uint16_t tone;
-
-  // while(1) {
-  //   tone = pwm_calculate_period(500);
-  //   pwm_timer_set_frequency(tone);
-  // }
-
   // Main Transmission Loop.
   while (1) {
     // Loop.

--- a/morse.c
+++ b/morse.c
@@ -62,7 +62,7 @@ char* MORSE_SYMBOLS[] = {
 // Send a single character
 void sendDotOrDash (char unit) {
 
-  radio_enable_tx();
+  radio_enable_tone();
 
   // Unit is a dot (500 ms)
   if (unit == MORSE_DOT) {
@@ -75,7 +75,7 @@ void sendDotOrDash (char unit) {
   }
 
   // Inter-element gap
-  radio_inhibit_tx();
+  radio_inhibit_tone();
   _delay_ms(MORSE_DELAY);
 }
 
@@ -98,6 +98,8 @@ void sendMorseSequence (char* sequence) {
 
 
 void sendMorse(char* message) {
+  
+  radio_enable_tx();
 
   int i = 0;
   while (message[i] != '\0') {

--- a/pwm.c
+++ b/pwm.c
@@ -1,0 +1,116 @@
+#include <stm32f10x.h>
+#include <core_cm3.h>
+#include <stm32f10x_rcc.h>
+#include <misc.h>
+#include <stm32f10x_tim.h>
+#include <stm32f10x_gpio.h>
+#include <stm32f10x_dma.h>
+#include <stdbool.h>
+#include "pwm.h"
+#include "config.h"
+#include "radio.h"
+
+DMA_Channel_TypeDef *pwm_dma_channel = DMA1_Channel2;
+
+void pwm_timer_init()
+{
+    TIM_DeInit(TIM15);
+    // GPIO_PinRemapConfig(GPIO_Remap_TIM15, DISABLE);
+
+    RCC_APB2PeriphClockCmd(RCC_APB2Periph_TIM15, ENABLE);
+    RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM15, DISABLE);
+
+    TIM_TimeBaseInitTypeDef tim_init;
+
+    // Not needed: TIM_InternalClockConfig(TIM15);
+
+    tim_init.TIM_Prescaler = 6 - 1; // tick every 1 us
+    tim_init.TIM_CounterMode = TIM_CounterMode_Up;
+    tim_init.TIM_Period = (uint16_t) (1000000 / (FM_TONE_FREQ * 4)) - 1;
+    tim_init.TIM_ClockDivision = TIM_CKD_DIV1;
+    tim_init.TIM_RepetitionCounter = 0;
+
+    TIM_TimeBaseInit(TIM15, &tim_init);
+
+    // TIM_OCInitTypeDef TIM15_OCInitStruct;
+
+    // TIM_OCStructInit(&TIM15_OCInitStruct);
+    // TIM15_OCInitStruct.TIM_Pulse = 0; // Was: tim_init.TIM_Period / 2
+    // TIM15_OCInitStruct.TIM_OCMode = TIM_OCMode_Toggle; // Was: TIM_OCMode_PWM1
+    // TIM15_OCInitStruct.TIM_OutputState = TIM_OutputState_Enable;
+    // TIM15_OCInitStruct.TIM_OCPolarity = TIM_OCPolarity_High;
+
+    // // TIM15 channel 2 can be used to drive pin PB15, which is connected to RS41 Si4032 SDI pin for direct modulation
+    // TIM_OC2Init(TIM15, &TIM15_OCInitStruct);
+
+    // // These are not needed?
+    // // TIM_SelectOCxM(TIM15, TIM_Channel_2, TIM_OCMode_PWM1);
+    // // TIM_CCxCmd(TIM15, TIM_Channel_2, TIM_CCx_Enable);
+
+    // // The following settings make transitions between generated frequencies smooth
+    // TIM_ARRPreloadConfig(TIM15, ENABLE);
+    // TIM_OC2PreloadConfig(TIM15, TIM_OCPreload_Enable);
+
+    // TIM_OC2FastConfig(TIM15, TIM_OCFast_Enable);
+
+    // TIM_CtrlPWMOutputs(TIM15, DISABLE);
+
+    TIM_ClearITPendingBit(TIM15, TIM_IT_Update);
+    TIM_ITConfig(TIM15, TIM_IT_Update, ENABLE);
+
+    NVIC_InitTypeDef nvic_init;
+    nvic_init.NVIC_IRQChannel = TIM1_BRK_TIM15_IRQn;
+    nvic_init.NVIC_IRQChannelPreemptionPriority = 2;
+    nvic_init.NVIC_IRQChannelSubPriority = 1;
+    nvic_init.NVIC_IRQChannelCmd = ENABLE;
+    NVIC_Init(&nvic_init);
+
+    TIM_Cmd(TIM15, ENABLE);
+}
+
+void pwm_timer_pwm_enable(bool enabled)
+{
+        TIM_Cmd(TIM15, enabled ? ENABLE : DISABLE);
+    // TIM_CtrlPWMOutputs(TIM15, enabled ? ENABLE : DISABLE);
+}
+
+void pwm_timer_use(bool use)
+{
+    // Remapping the TIM15 outputs will allow TIM15 channel 2 can be used to drive pin PB15,
+    // which is connected to RS41 Si4032 SDI pin for direct modulation
+    // GPIO_PinRemapConfig(GPIO_Remap_TIM15, use ? ENABLE : DISABLE);
+}
+
+void pwm_timer_uninit()
+{
+    TIM_CtrlPWMOutputs(TIM15, DISABLE);
+    TIM_Cmd(TIM15, DISABLE);
+
+    TIM_DeInit(TIM15);
+
+    // GPIO_PinRemapConfig(GPIO_Remap_TIM15, DISABLE);
+
+    RCC_APB2PeriphClockCmd(RCC_APB2Periph_TIM15, DISABLE);
+}
+
+inline uint16_t pwm_calculate_period(uint32_t frequency_hz)
+{
+    return (uint16_t) (1000000 / frequency_hz) - 1;
+}
+
+inline void pwm_timer_set_frequency(uint32_t pwm_period)
+{
+    TIM_SetAutoreload(TIM15, pwm_period);
+}
+
+void TIM1_BRK_TIM15_IRQHandler(void)
+{
+    static bool pin_state = false;
+
+    if (TIM_GetITStatus(TIM15, TIM_IT_Update) != RESET) {
+        TIM_ClearITPendingBit(TIM15, TIM_IT_Update);
+        // Restrict the interrupt to DFM17 only just in case this ISR gets called on RS41
+        pin_state = !pin_state;
+        GPIO_WriteBit(GPIOB, radioSDIpin, pin_state);
+    }
+}

--- a/pwm.h
+++ b/pwm.h
@@ -1,0 +1,32 @@
+#ifndef __PWM_H_
+#define __PWM_H_
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stm32f10x.h>
+#include <core_cm3.h>
+#include <stm32f10x_rcc.h>
+#include <misc.h>
+#include <stm32f10x_tim.h>
+#include <stm32f10x_gpio.h>
+#include <stdbool.h>
+#include "pwm.h"
+#include "config.h"
+
+void pwm_timer_init();
+
+void pwm_timer_pwm_enable(bool enabled);
+
+void pwm_timer_use(bool use);
+
+void pwm_timer_uninit();
+
+uint16_t pwm_calculate_period(uint32_t frequency_hz);
+
+void pwm_timer_set_frequency(uint32_t pwm_period);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/radio.h
+++ b/radio.h
@@ -9,6 +9,10 @@
 #include <stdint.h>
 #include <stm32f10x_spi.h>
 #include <stm32f10x_gpio.h>
+#include <stm32f10x_tim.h>
+#include "pwm.h"
+#include "init.h"
+#include "delay.h"
 
 static const uint16_t radioNSELpin = GPIO_Pin_13; // @ GPIOC
 static const uint16_t radioSDIpin = GPIO_Pin_15; // @ GPIOB!
@@ -25,13 +29,15 @@ uint8_t radio_rw_register(const uint8_t register_addr, uint8_t value, uint8_t wr
 
 void radio_set_tx_frequency(const float radio_set_tx_frequency);
 
+void radio_enable_tx();
+
 void radio_disable_tx();
 
 void radio_soft_reset();
 
-void radio_enable_tx();
+void radio_enable_tone();
 
-void radio_inhibit_tx();
+void radio_inhibit_tone();
 
 int8_t radio_read_temperature();
 


### PR DESCRIPTION
Add bit-banged FSK modulation to transmit signal to give CW tones via FM. This is enabled via flag in the config.h file. 

Reason: the majority of fox hunters in the area use FM HTs. Although CW technically works fine, there is a slight preference for "FM CW", especially amongst the new ham crowd.